### PR TITLE
Add new check for timezone adjustment

### DIFF
--- a/lib/comma/data_extractor.rb
+++ b/lib/comma/data_extractor.rb
@@ -38,7 +38,7 @@ module Comma
       end
 
       def time_zone_adjusted_value(output)
-        if output.respond_to?(:current_time_zone) && output.current_time_zone
+        if output.respond_to?(:in_time_zone) && output.respond_to?(:current_time_zone) && output.current_time_zone
           output.in_time_zone(output.current_time_zone)
         else
           output


### PR DESCRIPTION
We gotta check for `respond_to?(:in_time_zone)` in addition to `respond_to?(:current_time_zone)` or we'll have problems. An instance of `Site` would respond to `:current_time_zone` but not to `:in_time_zone`, for instance.
