### PR TITLE
Rails 4-related changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     fastercsv (1.5.4)
     i18n (0.6.5)
     multi_json (1.1.0)
-    rake (0.9.2.2)
+    rake (10.5.0)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
       rspec-expectations (~> 2.8.0)
@@ -39,7 +39,10 @@ DEPENDENCIES
   appraisal (~> 0.4.1)
   comma!
   fastercsv
-  rake (~> 0.9.2)
+  rake (~> 10.5.0)
   rspec (~> 2.8.0)
   simplecov
   sqlite3 (~> 1.3.4)
+
+BUNDLED WITH
+   1.11.2

--- a/comma.gemspec
+++ b/comma.gemspec
@@ -21,10 +21,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', ['>= 3.0.0']
 
-  s.add_development_dependency 'rake', ['~> 0.9.2']
+  s.add_development_dependency 'rake', ['~> 10.5.0']
   s.add_development_dependency 'sqlite3', ['~> 1.3.4']
   s.add_development_dependency 'appraisal', ['~> 0.4.1']
   s.add_development_dependency 'rspec', ['~> 2.8.0']
   s.add_development_dependency 'simplecov', ['>= 0']
-
 end

--- a/lib/comma/data_extractor.rb
+++ b/lib/comma/data_extractor.rb
@@ -38,7 +38,7 @@ module Comma
       end
 
       def time_zone_adjusted_value(output)
-        if output.respond_to?(:in_time_zone) && extraction_object.respond_to?(:current_time_zone) && extraction_object.current_time_zone
+        if output.is_a?(DateTime) && extraction_object.respond_to?(:current_time_zone) && extraction_object.current_time_zone
           output.in_time_zone(extraction_object.current_time_zone)
         else
           output


### PR DESCRIPTION
- Update gem requirements for Rails 4.0
- Use #is_a?(DateTime) to determine whether or not to use time zone.
