### PR TITLE
 [internal] Prepend an apostrophe to values beginning with a special char

### DIFF
--- a/lib/comma/sanitized_extractor.rb
+++ b/lib/comma/sanitized_extractor.rb
@@ -28,28 +28,50 @@ module Comma
     private
 
     # this is in case the result is only + and then numbers, as in the case of a phone number
-    def check_for_only_digits(result)
+    def result_only_numbers?(result)
       length = result.length
 
       result.start_with?("+") && (result.slice(1..length) !~ /\D/)
     end
 
+    def starts_with_dash?(result)
+      result.start_with?("-")
+    end
+
     # results would then transform from "+astring" to "'+astring"
-    def append_result_with_apostrophe(result)
+    def prepend_result_with_apostrophe(result)
       result = "'" + result
       result
     end
 
     # these character can cause excel to run malicious code if user clicks 'trust this'
-    def starts_with_special_characters(result)
+    def starts_with_special_characters?(result)
       result.start_with?("+", "-", "=", "@")
     end
 
-    # if the result begins with a bad character, prepend apostrophe, otherwise return it
+    def remove_special_characters_at_start(result)
+      while starts_with_special_characters(result)
+        result.slice!(0)
+      end
+      result
+    end
+
+    # sanitize the result in the following way:
+    # if it starts with a special character, do some additional checking
+    # if the result is a "+" and then only numbers, return it
+    # otherwise if it starts with a dash (ex. "-5.0") prepend an apostrophe
+    # otherwise remove and special characters at the start of the string
+    # if it doesnt start with a special character, leave it alone
     def sanitize_result(result)
       result = result.to_s
-      if starts_with_special_characters(result)
-        append_result_with_apostrophe(result)
+      if starts_with_special_characters?(result)
+        if result_only_numbers?(result)
+          result
+        elsif starts_with_dash?(result)
+          prepend_result_with_apostrophe(result)
+        else
+          remove_special_characters_at_start(result)
+        end
       else
         result
       end

--- a/lib/comma/sanitized_extractor.rb
+++ b/lib/comma/sanitized_extractor.rb
@@ -28,7 +28,7 @@ module Comma
     private
 
     # this is in case the result is only + and then numbers, as in the case of a phone number
-    def result_only_numbers?(result)
+    def only_numbers?(result)
       length = result.length
 
       result.start_with?("+") && (result.slice(1..length) !~ /\D/)
@@ -65,7 +65,7 @@ module Comma
     def sanitize_result(result)
       result = result.to_s
       if starts_with_special_characters?(result)
-        if result_only_numbers?(result)
+        if only_numbers?(result)
           result
         elsif starts_with_dash?(result)
           prepend_result_with_apostrophe(result)

--- a/lib/comma/sanitized_extractor.rb
+++ b/lib/comma/sanitized_extractor.rb
@@ -27,36 +27,35 @@ module Comma
 
     private
 
+    # this is in case the result is only + and then numbers, as in the case of a phone number
     def check_for_only_digits(result)
       length = result.length
 
       result.start_with?("+") && (result.slice(1..length) !~ /\D/)
     end
 
-    def remove_special_characters_at_start(result)
-      while starts_with_special_characters(result)
-        result.slice!(0)
-      end
+    # results would then transform from "+astring" to "'+astring"
+    def append_result_with_apostrophe(result)
+      result = "'" + result
       result
     end
 
+    # these character can cause excel to run malicious code if user clicks 'trust this'
     def starts_with_special_characters(result)
       result.start_with?("+", "-", "=", "@")
     end
 
+    # if the result begins with a bad character, prepend apostrophe, otherwise return it
     def sanitize_result(result)
       result = result.to_s
       if starts_with_special_characters(result)
-        if check_for_only_digits(result)
-          result
-        else
-          remove_special_characters_at_start(result)
-        end
+        append_result_with_apostrophe(result)
       else
         result
       end
     end
 
+    # sanitize the result unless it's nil
     def convert_to_data_value(result)
       if result.nil?
         result

--- a/lib/comma/sanitized_extractor.rb
+++ b/lib/comma/sanitized_extractor.rb
@@ -27,6 +27,11 @@ module Comma
 
     private
 
+    # these character can cause excel to run malicious code if user clicks 'trust this'
+    def starts_with_special_characters?(result)
+      result.start_with?("+", "-", "=", "@")
+    end
+
     # this is in case the result is only + and then numbers, as in the case of a phone number
     def only_numbers?(result)
       length = result.length
@@ -34,19 +39,30 @@ module Comma
       result.start_with?("+") && (result.slice(1..length) !~ /\D/)
     end
 
+    # check to see if the result is possibly just a negative number
     def starts_with_dash?(result)
       result.start_with?("-")
     end
 
-    # results would then transform from "+astring" to "'+astring"
-    def prepend_result_with_apostrophe(result)
-      result = "'" + result
-      result
+    # check to see if result is under 6 non-numerical characters
+    def under_six_non_numerical_characters?(result)
+      result.scan(/\D/).size <= 6
     end
 
-    # these character can cause excel to run malicious code if user clicks 'trust this'
-    def starts_with_special_characters?(result)
-      result.start_with?("+", "-", "=", "@")
+    # check to see if it is basically a negative number of some sort
+    # some sort of "-$2,123,456,789.00"
+    def retain_result_as_number?(result)
+      starts_with_dash?(result) && under_six_non_numerical_characters?(result)
+    end
+
+    # check if it starts with a dash and contains more than 6 non-numerical chars
+    def prepend_with_apostrophe?(result)
+      starts_with_dash?(result) && !under_six_non_numerical_characters?(result)
+    end
+
+    def prepend_with_apostrophe(result)
+      result = "'" + result
+      result
     end
 
     def remove_special_characters_at_start(result)
@@ -60,6 +76,7 @@ module Comma
     # if it starts with a special character, do some additional checking
     # if the result is a "+" and then only numbers, return it
     # otherwise if it starts with a dash (ex. "-5.0") prepend an apostrophe
+    # only if it's more than 10 digits
     # otherwise remove and special characters at the start of the string
     # if it doesnt start with a special character, leave it alone
     def sanitize_result(result)
@@ -67,8 +84,10 @@ module Comma
       if starts_with_special_characters?(result)
         if only_numbers?(result)
           result
-        elsif starts_with_dash?(result)
-          prepend_result_with_apostrophe(result)
+        elsif retain_result_as_number?(result)
+          result
+        elsif prepend_with_apostrophe?(result)
+          prepend_with_apostrophe(result)
         else
           remove_special_characters_at_start(result)
         end

--- a/spec/comma/sanitized_data_extractor_spec.rb
+++ b/spec/comma/sanitized_data_extractor_spec.rb
@@ -103,11 +103,12 @@ describe Comma::SanitizedDataExtractor, 'value starting with "-", "+", "=", "@"'
         name 'name' do |name| '+somestring' end
         name 'name' do |name| '-@1morestr1n6' end
         name 'name' do |name| '+1234567890' end
+        name 'name' do |name| '-.50' end
       end
     end.new(1).to_comma_sanitized
   end
 
-  it 'removes special characters for non digits and leaves only digits alone' do
-    @data.should eq(["somestring", "1morestr1n6", "+1234567890"])
+  it 'prepends an apostrophe in front of values that start with a special character unless it is only digits' do
+    @data.should eq(["'+somestring", "'-@1morestr1n6", "+1234567890", "'-.50"])
   end
 end

--- a/spec/comma/sanitized_data_extractor_spec.rb
+++ b/spec/comma/sanitized_data_extractor_spec.rb
@@ -100,19 +100,20 @@ describe Comma::SanitizedDataExtractor, 'value starting with "-", "+", "=", "@"'
   before do
     @data = Class.new(Struct.new(:name)) do
       comma do
-        name 'name' do |name| '+somestring' end
-        name 'name' do |name| '-@1morestr1n6' end
         name 'name' do |name| '+1234567890' end
-        name 'name' do |name| '-.50' end
+        name 'name' do |name| '-$2,123,123,123.00' end
+        name 'name' do |name| '-@1morestr1n6' end
+        name 'name' do |name| '+somestring' end
       end
     end.new(1).to_comma_sanitized
   end
 
   # strings that start with a special character +-=@ are sanitized the following ways:
   # + and any number of digits (+2321432423) is un-modified
-  # - will have an apostrophe prepended to protect integrity of negative values
+  # - and less than 7 non-numerical characters is un-modified
+  # - and more than 7 non-numerical characters has an apostrophe prepended
   # other symbols are sliced off the front of strings
   it 'sanitizes the values of the strings' do
-    @data.should eq(["+somestring", "'-@1morestr1n6", "+1234567890", "'-.50"])
+    @data.should eq(["+1234567890", "-$2,123,123,123.00", "'-@1morestr1n6", "+somestring"])
   end
 end

--- a/spec/comma/sanitized_data_extractor_spec.rb
+++ b/spec/comma/sanitized_data_extractor_spec.rb
@@ -108,7 +108,11 @@ describe Comma::SanitizedDataExtractor, 'value starting with "-", "+", "=", "@"'
     end.new(1).to_comma_sanitized
   end
 
-  it 'prepends an apostrophe in front of values that start with a special character unless it is only digits' do
-    @data.should eq(["'+somestring", "'-@1morestr1n6", "+1234567890", "'-.50"])
+  # strings that start with a special character +-=@ are sanitized the following ways:
+  # + and any number of digits (+2321432423) is un-modified
+  # - will have an apostrophe prepended to protect integrity of negative values
+  # other symbols are sliced off the front of strings
+  it 'sanitizes the values of the strings' do
+    @data.should eq(["+somestring", "'-@1morestr1n6", "+1234567890", "'-.50"])
   end
 end


### PR DESCRIPTION
A different approach to solving: https://github.com/chargify/chargify/issues/11054 . 
This would prepend any values starting with a special character with an apostrophe '

The plan is to sanitize a little more dynamically.
Any strings that begin with + and are only numbers will be left intact
Any strings that begin with - and contain 6 or less non-numbers (so like `-$1,234,567,890.00`) will be left intact.
Strings that begin with - and contain more than 6 non numbers will have an apostrophe prepended (just to ensure we dont convert something to positive that should remain negative)
Strings that begin with @ or = will have those values stripped off the front.