### PR TITLE
[internal] Add support for globals

### DIFF
--- a/lib/comma/data_extractor.rb
+++ b/lib/comma/data_extractor.rb
@@ -8,7 +8,7 @@ module Comma
   class DataExtractor < Extractor
 
     def multicolumn(method, &block)
-      Comma::MulticolumnExtractor.new(@instance, method, &block).extract_values.each do |result|
+      Comma::MulticolumnExtractor.new(@instance, method, @globals, &block).extract_values.each do |result|
         @results << result
       end
     end

--- a/lib/comma/extractor.rb
+++ b/lib/comma/extractor.rb
@@ -2,10 +2,11 @@
 
 module Comma
   class Extractor
-    def initialize(instance, style, formats)
+    def initialize(instance, style, formats, globals = {})
       @instance = instance
       @style = style
       @formats = formats
+      @globals = globals
       @results = []
     end
 

--- a/lib/comma/generator.rb
+++ b/lib/comma/generator.rb
@@ -7,6 +7,7 @@ module Comma
       @style    = style
       @options  = {}
       @sanitized = false
+      @globals = {}
 
       return unless @style.is_a?(Hash)
 
@@ -14,6 +15,7 @@ module Comma
       @style                    = @options.delete(:style) || Comma::DEFAULT_OPTIONS[:style]
       @filename                 = @options.delete(:filename)
       @sanitized                = @options.delete(:sanitized) || false
+      @globals                  = @options.delete(:globals) || {}
     end
 
     def run(iterator_method)
@@ -29,10 +31,10 @@ module Comma
     def append_csv(csv, iterator_method)
       return '' if @instance.empty?
 
-      csv << @instance.first.to_comma_headers(@style) unless
+      csv << @instance.first.to_comma_headers(@style, @globals) unless
         @options.key?(:write_headers) && !@options[:write_headers]
       @instance.send(iterator_method) do |object|
-        csv << object.to_comma(@style, @sanitized)
+        csv << object.to_comma(@style, @sanitized, @globals)
       end
     end
   end

--- a/lib/comma/header_extractor.rb
+++ b/lib/comma/header_extractor.rb
@@ -17,7 +17,7 @@ module Comma
     self.value_humanizer = DEFAULT_VALUE_HUMANIZER
 
     def multicolumn(method, &block)
-      Comma::MulticolumnExtractor.new(@instance, method, &block).extract_header.each do |result|
+      Comma::MulticolumnExtractor.new(@instance, method, @globals, &block).extract_header.each do |result|
         @results << result
       end
     end

--- a/lib/comma/multicolumn_extractor.rb
+++ b/lib/comma/multicolumn_extractor.rb
@@ -2,10 +2,10 @@ require "ostruct"
 
 module Comma
   class MulticolumnExtractor
-    attr_accessor :instance, :method, :block
+    attr_accessor :instance, :method, :block, :globals
 
-    def initialize(instance, method, &block)
-      @instance, @method, @block = instance, method, block
+    def initialize(instance, method, globals, &block)
+      @instance, @method, @globals, @block = instance, method, globals, block
     end
 
     def extract_header
@@ -26,7 +26,7 @@ module Comma
         children = instance.send(method)
         [children].flatten.compact.each do |child|
           memo = Array.new
-          block.yield memo, instance, child
+          block.yield(memo, instance, child, globals)
           memo.each{|m| output << OpenStruct.new(m) }
         end
       end

--- a/lib/comma/object.rb
+++ b/lib/comma/object.rb
@@ -18,23 +18,23 @@ class Object
     end
   end
 
-  def to_comma(style = :default, sanitized = false)
+  def to_comma(style = :default, sanitized = false, globals = {})
     if !sanitized
-      extract_with(Comma::DataExtractor, style)
+      extract_with(Comma::DataExtractor, style, globals)
     else
-      extract_with(Comma::SanitizedDataExtractor, style)
+      extract_with(Comma::SanitizedDataExtractor, style, globals)
     end
   end
 
-  def to_comma_headers(style = :default)
-    extract_with(Comma::HeaderExtractor, style)
+  def to_comma_headers(style = :default, globals = {})
+    extract_with(Comma::HeaderExtractor, style, globals)
   end
 
   private
 
-  def extract_with(extractor_class, style = :default)
+  def extract_with(extractor_class, style = :default, globals = {})
     raise_unless_style_exists(style)
-    extractor_class.new(self, style, self.comma_formats).results
+    extractor_class.new(self, style, self.comma_formats, globals).results
   end
 
   def raise_unless_style_exists(style)

--- a/lib/comma/sanitized_data_extractor.rb
+++ b/lib/comma/sanitized_data_extractor.rb
@@ -6,7 +6,7 @@ module Comma
   class SanitizedDataExtractor < SanitizedExtractor
 
     def multicolumn(method, &block)
-      Comma::MulticolumnExtractor.new(@instance, method, &block).extract_values.each do |result|
+      Comma::MulticolumnExtractor.new(@instance, method, @globals, &block).extract_values.each do |result|
         @results << result
       end
     end

--- a/lib/comma/sanitized_extractor.rb
+++ b/lib/comma/sanitized_extractor.rb
@@ -4,10 +4,11 @@ module Comma
 
   class SanitizedExtractor < Extractor
 
-    def initialize(instance, style, formats)
+    def initialize(instance, style, formats, globals)
       @instance = instance
       @style = style
       @formats = formats
+      @globals = globals
       @results = []
     end
 

--- a/spec/comma/comma_spec.rb
+++ b/spec/comma/comma_spec.rb
@@ -98,6 +98,11 @@ describe Comma, 'generating CSV with multicolumn dynamic fields' do
   it 'should extend Array to add a #to_comma method which will return CSV content for objects within the array' do
     [nested_field].to_comma.should == "Name,OBJ ~ ID,OBJ ~ Name,OBJ ~ Value,OBJ ~ ID,OBJ ~ Name,OBJ ~ Value\nFred,123,Foo,fritz,123,Bar,bank\n"
   end
+
+  it 'should pass globals to multicolumn block' do
+    field_with_global = MultiAttributeFieldWithGlobals.new("Fred", fields)
+    expect([field_with_global].to_comma(globals: { from_global: 'some_value_from_global' } )).to eq("Name,from_global,from_global\nFred,some_value_from_global,some_value_from_global\n")
+  end
 end
 
 describe Comma, 'defining CSV descriptions' do

--- a/spec/non_rails_app/ruby_classes.rb
+++ b/spec/non_rails_app/ruby_classes.rb
@@ -54,6 +54,21 @@ class MultiAttributeField
   end
 end
 
+class MultiAttributeFieldWithGlobals
+  attr_accessor :name, :address, :number, :children
+
+  def initialize(name,  children = [])
+    @name, @children = name, children
+  end
+
+  comma do
+    name
+    multicolumn :children do |result, _field, _child, globals|
+      result << { 'name' => 'from_global', 'value' => globals[:from_global]}
+    end
+  end
+end
+
 class Field
   attr_accessor :name, :value
 


### PR DESCRIPTION
Globals are precomputed variables which can be reused inside `multicolumn` blocks. Thanks to them expensive operations can be avoided on row level. 

Changes are backwards compatible. 

Example:

Before:
```ruby
comma do
  id "id"
  first_name "first_name"

  multicolumn :site do |result, record, site|
    if site.expensive_operation?
      result << { name: "verified", value: record.verified }
    end
  end
end

# ...

ar_relation.to_comma

```

After:
```ruby
comma do
  id "id"
  first_name "first_name"

  multicolumn :site do |result, record, site, globals|
    if globals.fetch(:expensive_operation) { site.expensive_operation? }
      result << { name: "verified", value:  record.verified }
    end
  end
end

# ...

ar_relation.to_comma(globals: { expensive_operation: site.expensive_operation? })
```
