### PR TITLE
Allowing negative digits in sanitization

### DIFF
--- a/lib/comma/sanitized_extractor.rb
+++ b/lib/comma/sanitized_extractor.rb
@@ -31,7 +31,7 @@ module Comma
     def check_for_only_digits(result)
       length = result.length
 
-      result.start_with?("+") && (result.slice(1..length) !~ /\D/)
+      result.start_with?("+", "-") && (result.slice(1..length) !~ /\D/)
     end
 
     def remove_special_characters_at_start(result)

--- a/spec/comma/data_extractor_spec.rb
+++ b/spec/comma/data_extractor_spec.rb
@@ -97,11 +97,12 @@ describe Comma::DataExtractor, 'value starting with "-", "+", "=", "@"' do
         name 'name' do |name| '+somestring' end
         name 'name' do |name| '-@1morestr1n6' end
         name 'name' do |name| '+1234567890' end
+        name 'name' do |name| '-1234567890' end
       end
     end.new(1).to_comma
   end
 
   it 'not change any of the values' do
-    @data.should eq(["+somestring", "-@1morestr1n6", "+1234567890"])
+    @data.should eq(["+somestring", "-@1morestr1n6", "+1234567890", "-1234567890"])
   end
 end

--- a/spec/comma/sanitized_data_extractor_spec.rb
+++ b/spec/comma/sanitized_data_extractor_spec.rb
@@ -103,11 +103,13 @@ describe Comma::SanitizedDataExtractor, 'value starting with "-", "+", "=", "@"'
         name 'name' do |name| '+somestring' end
         name 'name' do |name| '-@1morestr1n6' end
         name 'name' do |name| '+1234567890' end
+        name 'name' do |name| '-1234567890' end
+        name 'name' do |name| '-2+3+cmd|' end
       end
     end.new(1).to_comma(:default, true)
   end
 
   it 'removes special characters for non digits and leaves only digits alone' do
-    @data.should eq(["somestring", "1morestr1n6", "+1234567890"])
+    @data.should eq(["somestring", "1morestr1n6", "+1234567890", "-1234567890", "2+3+cmd|"])
   end
 end

--- a/spec/comma/sanitized_data_extractor_spec.rb
+++ b/spec/comma/sanitized_data_extractor_spec.rb
@@ -38,7 +38,7 @@ describe Comma::SanitizedDataExtractor do
 
       it 'should use the string value, returned by sending the hash key to the object' do
         @data.should include('+123123123')
-        @data.should include('321321321')
+        @data.should include('-321321321')
       end
 
       it 'should not fail when an associated object is nil' do


### PR DESCRIPTION
**Change**:
With option sanitized :true

We will allow negative digits like -2000 to pass sanitization logic. Since it is perfectly safe to have them if after minus sign string contains nothing more than digits.
